### PR TITLE
feat: add pack validation CI workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,11 +5,16 @@ on:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
   pull_request:
     paths:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   validate:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate
+on:
+  push:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+  pull_request:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+
+jobs:
+  validate:
+    uses: JacobPEvans/.github/.github/workflows/_cribl-pack-validate.yml@main
+    with:
+      pack-type: stream


### PR DESCRIPTION
## Summary

- Add `validate.yml` GitHub Actions workflow that calls the shared `_cribl-pack-validate.yml` reusable workflow from JacobPEvans/.github
- Configured with `pack-type: stream` for Cribl Stream pack validation
- Triggers on push/PR changes to `default/**`, `data/**`, `package.json`, and `.github/workflows/validate.yml`
- Includes `workflow_dispatch` for manual runs
- Minimal `permissions: {}` block to satisfy CodeQL security scanning

## Changes

- New file: `.github/workflows/validate.yml`

## Test Plan

- [x] Reusable workflow `_cribl-pack-validate.yml` is on main in JacobPEvans/.github (`.github` PR #132 merged)
- [ ] Confirm `workflow_dispatch` allows manual trigger post-merge
- [x] Validate pack-type is correct for this repo (`stream`)

Closes #2
