### PR TITLE
docs: link to ansible-proxmox-apps cribl_packs role for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # cc-stream-github-copilot-rest-io
 
-Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level. Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array responses into individual events for downstream analysis.
+Collects GitHub Copilot usage metrics from the GitHub REST API at the
+org, team, and user level. Polls the Copilot usage metrics endpoints on
+a configurable schedule and breaks JSON array responses into individual
+events for downstream analysis.
 
 ## Pack Components
 
@@ -45,11 +48,33 @@ All collectors are delivered **disabled** by default. Enable the collectors you 
 
 ### Rate Limiting
 
-All collectors include automatic retry with exponential backoff (1s base, 3 retries, 2x multiplier) for HTTP 429 and 503 responses.
+All collectors include automatic retry with exponential backoff (1s
+base, 3 retries, 2x multiplier) for HTTP 429 and 503 responses.
 
 ### Event Breaker
 
-The `jsonArrayField` is left empty for top-level JSON arrays. If the API response structure changes, adjust the `jsonArrayField` in the `GitHub Copilot Usage Ruleset`.
+The `jsonArrayField` is left empty for top-level JSON arrays. If the
+API response structure changes, adjust the `jsonArrayField` in the
+`GitHub Copilot Usage Ruleset`.
+
+## Deployment
+
+Production install onto the homelab Cribl Stream LXCs is automated by
+the `cribl_packs` role in
+[ansible-proxmox-apps](https://github.com/JacobPEvans/ansible-proxmox-apps/tree/main/roles/cribl_packs).
+Pack version is pinned in `roles/cribl_packs/defaults/main.yml`.
+
+To roll out a new release: cut a tag in this repo (publishes the `.crbl`
+asset), bump `version:` for `cc-stream-github-copilot-rest-io` in
+`ansible-proxmox-apps/roles/cribl_packs/defaults/main.yml`, then run
+`ansible-playbook playbooks/site.yml --tags cribl_packs` from that repo.
+The role downloads the matching `.crbl`, unpacks it into
+`/opt/cribl/local/cribl/packs/cc-stream-github-copilot-rest-io/`, and
+restarts `cribl.service` only when the version actually changed.
+
+Note: all REST collectors in this pack ship **disabled** by default.
+After install, enable the collectors and configure
+`github_pat` / `github_org` / `github_team_slug` in Cribl Stream UI.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Pack version is pinned in `roles/cribl_packs/defaults/main.yml`.
 
 To roll out a new release: cut a tag in this repo (publishes the `.crbl`
 asset), bump `version:` for `cc-stream-github-copilot-rest-io` in
-`ansible-proxmox-apps/roles/cribl_packs/defaults/main.yml`, then run
+`roles/cribl_packs/defaults/main.yml`, then run
 `ansible-playbook playbooks/site.yml --tags cribl_packs` from that repo.
 The role downloads the matching `.crbl`, unpacks it into
 `/opt/cribl/local/cribl/packs/cc-stream-github-copilot-rest-io/`, and


### PR DESCRIPTION
## Summary

Documents the production install path. The `cribl_packs` role in [ansible-proxmox-apps](https://github.com/JacobPEvans/ansible-proxmox-apps/tree/main/roles/cribl_packs) now deploys this pack onto the homelab Cribl Stream LXCs from the `.crbl` GitHub release asset.

Adds a "Deployment" section before "Release Notes" with the version-bump workflow and a reminder that all 3 REST collectors ship disabled by default — post-install configuration of `github_pat`/`github_org`/`github_team_slug` is required.

Also wraps several long lines to fix MD013 line-length.

## Test plan

- [x] markdownlint clean
- [ ] CI link checks pass