### PR TITLE
chore(claude): enable scoped plugins via .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledPlugins": {
+    "cribl-pack-validator@vct-cribl-pack-validator-skills": true
+  }
+}


### PR DESCRIPTION
## Summary

Per-repo override for Claude Code plugin scoping ([nix-ai #721](https://github.com/JacobPEvans/nix-ai/pull/721)).

`cribl-pack-validator@vct-cribl-pack-validator-skills` is disabled at user level in `nix-ai` so it does not bloat the global Claude Code skill-listing budget for sessions in non-Cribl repos. This adds a project-scoped `.claude/settings.json` so the plugin reloads automatically inside this worktree (Claude Code deep-merges project settings on top of user settings).

## Test plan

- [ ] Fresh Claude Code session inside this repo → `/skills` lists `cribl-pack-validator`
- [ ] Fresh Claude Code session inside an unrelated repo (e.g. `nix-ai`) → that plugin is NOT listed