### PR TITLE
chore(ci): add link-checker.lock caller [routine:distributor]

### DIFF
--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -1,0 +1,8 @@
+name: link-checker.lock
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  run:
+    uses: dryvist/ai-workflows/.github/workflows/link-checker.lock.yml@facc9a67ffdda22c75f5a94964fc5ab266cf3a60 # v0.16.0


### PR DESCRIPTION
The Distributor propagation PR.

## Workflow

`link-checker.lock.yml` — thin caller for [dryvist/ai-workflows](https://github.com/dryvist/ai-workflows) reusable workflow, pinned to `facc9a67ffdda22c75f5a94964fc5ab266cf3a60` (`v0.16.0`).

## Why this repo

Repo has `.github/workflows/` directory → core tier.

## Required secrets

None — workflow uses only public APIs and runner-injected `GITHUB_TOKEN`.

## Checklist

- [ ] Workflow trigger appropriate for this repo's branch model
- [ ] Required secrets exist in repo settings (if applicable)
- [ ] CI passes on the PR branch before merge

## Provenance

- **Generated by:** [The Distributor](https://claude.ai/code) — cloud routine, daily at 14:00 UTC
- **Triggered:** Scheduled run on `2026-05-29`
- **Why this PR:** `JacobPEvans-personal/cc-stream-github-copilot-rest-io` matched the `core` tier predicate and is missing `link-checker.lock.yml` (Phase 4 gap rank #2).
- **State:** `distributor-state` gist — tracks closed-pair memory so previously-rejected combinations are not re-attempted.
- **Label:** `cloud-routine`
