### PR TITLE
docs(cc-stream-github-copilot-rest-io): polish README - 2 fixes [routine:daily-polish]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cc-stream-github-copilot-rest-io
 
+![Build Release](https://github.com/JacobPEvans-personal/cc-stream-github-copilot-rest-io/actions/workflows/release.yml/badge.svg)
+
 Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level. Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array responses into individual events for downstream analysis.
 
 ## Pack Components
@@ -59,3 +61,7 @@ The `jsonArrayField` is left empty for top-level JSON arrays. If the API respons
 - 3 REST collectors (org, team, user level)
 - JSON array event breaker for Copilot usage metrics
 - Configurable variables for org, PAT, team, and API base URL
+
+## License
+
+No license specified. Contact the repository owner for usage rights.


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

3/5 passing.

Failing checks:
- ci-badge: No CI badge in README
- license: No license badge or mention in README

## Fixes applied

- ci-badge: Added `![Build Release]` badge pointing to `release.yml` workflow
- license: Added `## License` section with placeholder text noting no license is specified

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/cc-stream-github-copilot-rest-io-2026-05-30` branch: improved from 3 -> 5 passing.

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/daily-polish.prompt.md) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-05-30
- **Why this PR:** cc-stream-github-copilot-rest-io was selected from the rotation (state gist `daily-polish-state`); 2/5 checks failed.
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans-personal/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
