### PR TITLE
docs: add data contract + normalize metadata (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # cc-stream-github-copilot-rest-io
 
-Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level. Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array responses into individual events for downstream analysis.
+## Overview
+
+Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level.
+Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array
+responses into individual events for downstream analysis.
+
+This is a **Cribl Stream** pack (scheduled REST collectors), not a Cribl Edge pack.
 
 ## Pack Components
 
@@ -10,6 +16,26 @@ Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team,
 | `GitHub_Copilot_Team_Usage` | REST Collector | Every 6 hours | No | Team-level Copilot usage metrics |
 | `GitHub_Copilot_User_Usage` | REST Collector | Every 6 hours | No | User-level Copilot usage metrics |
 | `GitHub Copilot Usage Ruleset` | Event Breaker | — | — | Breaks JSON array response into individual daily metrics |
+
+## Data Sources
+
+- **GitHub REST API — Copilot usage metrics** at the org, team, and user level, polled every
+  6 hours by three scheduled REST collectors (all delivered disabled by default)
+
+## Data Contract
+
+Events leave this pack tagged with a `datatype` metadata field; Cribl Stream maps datatypes to
+Splunk sourcetypes/indexes per the table below. Knowledge objects for the sourcetypes ship in
+[VisiCore_TA_AI_Observability](https://github.com/JacobPEvans/VisiCore_TA_AI_Observability) (v0.2.0+).
+
+The datatype is driven by the `datatype` pack variable (default `github:copilot:usage`) and is
+shared by all three collectors.
+
+| Input | Datatype | Splunk sourcetype | Index | TA support |
+|---|---|---|---|---|
+| `GitHub_Copilot_Org_Usage` | `github:copilot:usage` | `github:copilot:usage` | `vscode` | ✓ (0.2.0+) |
+| `GitHub_Copilot_Team_Usage` | `github:copilot:usage` | `github:copilot:usage` | `vscode` | ✓ (0.2.0+) |
+| `GitHub_Copilot_User_Usage` | `github:copilot:usage` | `github:copilot:usage` | `vscode` | ✓ (0.2.0+) |
 
 ## Setup
 
@@ -49,9 +75,15 @@ All collectors include automatic retry with exponential backoff (1s base, 3 retr
 
 ### Event Breaker
 
-The `jsonArrayField` is left empty for top-level JSON arrays. If the API response structure changes, adjust the `jsonArrayField` in the `GitHub Copilot Usage Ruleset`.
+The `jsonArrayField` is left empty for top-level JSON arrays. If the API response structure
+changes, adjust the `jsonArrayField` in the `GitHub Copilot Usage Ruleset`.
 
 ## Release Notes
+
+### v1.0.1
+
+- Docs: add Overview, Data Sources, and Data Contract sections; clarify this is a Cribl Stream pack
+- Chore: normalize `package.json` metadata (trim author whitespace, move `vct` first in tags, pretty-print)
 
 ### v1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,1 +1,23 @@
-{"name":"cc-stream-github-copilot-rest-io","version":"1.0.0","minLogStreamVersion":"4.14.0","author":"VisiCore Tech - CriblPacks@VisiCoreTech.com ","description":"Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level. Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array responses into individual events for downstream analysis.","displayName":"GitHub Copilot Usage Metrics REST Collector","tags":{"streamtags":["github","copilot","rest","vct"],"dataType":["metrics"],"useCase":["routing"]},"exports":[]}
+{
+  "name": "cc-stream-github-copilot-rest-io",
+  "version": "1.0.1",
+  "minLogStreamVersion": "4.14.0",
+  "author": "VisiCore Tech - CriblPacks@VisiCoreTech.com",
+  "description": "Collects GitHub Copilot usage metrics from the GitHub REST API at the org, team, and user level. Polls the Copilot usage metrics endpoints on a configurable schedule and breaks JSON array responses into individual events for downstream analysis.",
+  "displayName": "GitHub Copilot Usage Metrics REST Collector",
+  "tags": {
+    "streamtags": [
+      "vct",
+      "github",
+      "copilot",
+      "rest"
+    ],
+    "dataType": [
+      "metrics"
+    ],
+    "useCase": [
+      "routing"
+    ]
+  },
+  "exports": []
+}


### PR DESCRIPTION
## Summary

Part of the cc-* pack consistency sweep:

- New **Data Contract** README section: input -> datatype -> Splunk sourcetype -> index -> TA
  support, aligned with VisiCore_TA_AI_Observability v0.2.0.
- package.json normalized: canonical author string (trailing space removed where present),
  vct-first tags, pretty-printed.
- Patch bump to v1.0.1 (README ships inside the released .crbl artifact).
- Notes this is a Cribl Stream pack (REST collectors), not Edge; datatype is variable-driven (`github:copilot:usage`).

No pipeline/inputs behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)