### PR TITLE
refactor(ci): extract inline build script to scripts/ [routine:inspector]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          # Versioned filename for archival
-          tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
-            data default package.json README.md
-          # Fixed filename for latest-download URLs
-          cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"
+        run: bash scripts/build-crbl-pack.sh
 
       - name: Upload to release
         env:

--- a/scripts/build-crbl-pack.sh
+++ b/scripts/build-crbl-pack.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Versioned filename for archival
+tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
+  data default package.json README.md
+# Fixed filename for latest-download URLs
+cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"


### PR DESCRIPTION
The Inspector report.

## Rule

`no-scripts` — multi-line inline bash in `run:` blocks should live in `scripts/` so they can be linted, tested, and version-controlled independently.

## Finding

File: `.github/workflows/release.yml`
Line range: `L19-L25`
Severity: `low` (1 violation, 5 non-blank lines)

Step: **Build .crbl pack** (`build` job) — 5-line `run:` block (2 commands + inline comments) extracted to `scripts/build-crbl-pack.sh`. The `Upload to release` step (3 lines) is below threshold and unchanged.

## Action

Added `scripts/build-crbl-pack.sh` containing the extracted tar/cp logic; replaced the `run: |` block in `release.yml` with `run: bash scripts/build-crbl-pack.sh`. No semantic change — env vars `REPO_NAME` and `TAG_NAME` are still injected via the step's `env:` block.

Re-scan with the no-scripts detector returns zero violations.

---

## Provenance

- **Generated by:** [The Inspector](https://github.com/JacobPEvans-personal/.github/blob/main/routines/inspector.prompt.md) — cloud routine, daily at 06:00 UTC.
- **Triggered:** Today's rotation landed on rule `no-scripts` (day-of-year mod 3 = 2).
- **Why this PR/issue:** `JacobPEvans-personal/cc-stream-github-copilot-rest-io` had the largest extractable run-block (5 lines) among repos without `required_signatures` branch rules; `secrets-sync` and most other repos with larger violations block unverified commits.
- **State:** `inspector-state` gist — tracks per-`(repo, rule)` cooldowns and content-hash caches.
- **Label:** `cloud-routine`