### PR TITLE
docs(readme): add Usage section with SPL example [routine:archivist]

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ All collectors are delivered **disabled** by default. Enable the collectors you 
 2. **Team-level**: Enable `GitHub_Copilot_Team_Usage` — also requires `github_team_slug`
 3. **User-level**: Enable `GitHub_Copilot_User_Usage` — requires `github_pat` with user-level scopes
 
+## Usage
+
+After enabling collectors, verify data is flowing by searching your destination for events
+with the configured sourcetype:
+
+```spl
+index=vscode sourcetype="github:copilot:usage"
+| stats sum(total_suggestions_count) as suggestions
+        sum(total_acceptances_count) as acceptances
+        BY day
+| eval acceptance_rate=round(acceptances/suggestions*100, 1)
+| sort -day
+```
+
+To trigger a one-time run without waiting for the schedule, use **Datagen > Jobs > Run Now**
+for the desired collector in the Cribl Stream UI. Each event represents one day of metrics
+at the requested scope (org, team, or user); the `day` field contains the date in `YYYY-MM-DD`
+format.
+
 ## Troubleshooting
 
 ### Rate Limiting


### PR DESCRIPTION
The Archivist README quality fix.

## Gap

Check 4 failed: `missing_usage`. The README quality scorer measures six items from https://www.makeareadme.com/ and https://github.com/matiassingers/awesome-readme.

The README has a `## Setup` section (check 3 pass) but no `## Usage`, `## Examples`, or `## Example` section, and the Setup section contains no indented/fenced code block of 3 or more lines.

## Proposed fix

Added a `## Usage` section between Setup and Troubleshooting with a 9-line SPL search example and guidance on how to trigger a manual collector run and interpret the output.

## Other checks

| # | Check | Status |
|---|---|---|
| 1 | Exists | ✓ |
| 2 | Purpose paragraph | ✓ |
| 3 | Quickstart (`## Setup`) | ✓ |
| 4 | Usage/examples | ✗ → fixed |
| 5 | License | ✗ (no LICENSE file — separate concern) |
| 6 | Length (93 lines) | ✓ |

---

## Provenance

- **Generated by:** [The Archivist](https://github.com/JacobPEvans-personal/.claude/blob/main/routines/archivist.prompt.md) — cloud routine, daily at 09:00 UTC, task `readme-quality`.
- **Triggered:** Daily rotation landed on `readme-quality` (epoch-days mod 2 = 0).
- **Why this PR:** `JacobPEvans-personal/cc-stream-github-copilot-rest-io` was the most-recently-pushed repo among score-4/6 candidates not on 14-day cooldown and without an open archivist PR. Score-0 repos (obsidian-education, obsidian-personal, obsidian-personal-projects, int_resume) have open issues; score-2 (int_ai-assistant-contexts) has an open PR; score-3 repos are on cooldown.
- **State:** `archivist-state` gist — 14-day cooldown per `(repo, task)`.
- **Label:** `cloud-routine`
