### PR TITLE
docs(readme): add ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ changes, adjust the `jsonArrayField` in the `GitHub Copilot Usage Ruleset`.
 - 3 REST collectors (org, team, user level)
 - JSON array event breaker for Copilot usage metrics
 - Configurable variables for org, PAT, team, and API base URL
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary
- Add the standard docs.jacobpevans.com ecosystem footer to README.md, matching the format used across other public repos.

## Test plan
- [x] Docs only, no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj9ZFKDR2iCis44dC2y8Hu